### PR TITLE
Bugfix/readme reference incorrect GitHub oauth scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Start up your pipeline, which will deploy to 2 environments, "test" and
 Mu will ask you for a GitHub token. CodePipeline uses it to watch your
 repo for changes so that it can automatically deploy them.
 [Create a new token](https://github.com/settings/tokens) in your own
-GitHub account and grant it the "admin:repo_hook" and "admin" permissions.
+GitHub account and grant it the "admin:repo_hook" and "repo" permissions.
 Save it somewhere, like [a nice password manager](https://1password.com).
 Enter it when mu asks for it. (But don't give it to anything else! ;^)
 

--- a/mu.yml
+++ b/mu.yml
@@ -82,7 +82,7 @@ service:
 
       #### The GitHub repo slug or CodeCommit repo name to build
       #### (default: none)
-      repo: mullinsr/mu-wordpress
+      repo: stelligent/mu-wordpress
 
     acceptance:
       #### The environment name to deploy to for testing

--- a/mu.yml
+++ b/mu.yml
@@ -82,7 +82,7 @@ service:
 
       #### The GitHub repo slug or CodeCommit repo name to build
       #### (default: none)
-      repo: stelligent/mu-wordpress
+      repo: mullinsr/mu-wordpress
 
     acceptance:
       #### The environment name to deploy to for testing

--- a/mu.yml
+++ b/mu.yml
@@ -92,3 +92,4 @@ service:
       #### The environment name to deploy to for production
       #### (default: production)
       environment: prod
+      


### PR DESCRIPTION
There is no `admin` oAuth scope. Official docs here reference the correct oauth scopes - https://github.com/stelligent/devops-essentials/wiki/Prerequisites#create-an-oauth-token-in-github

updating README to reflect this